### PR TITLE
[#25] 로그아웃, 회원탈퇴 구현

### DIFF
--- a/core/src/main/java/project/side/ikdaman/core/view/AuthDialogs.kt
+++ b/core/src/main/java/project/side/ikdaman/core/view/AuthDialogs.kt
@@ -1,0 +1,181 @@
+package project.side.ikdaman.core.view
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+
+@Composable
+fun AppDialog(
+    title: String = "",
+    visible: Boolean = true,
+    enabled: Boolean = true,
+    cancelButtonText: String = "아니요",
+    confirmButtonText: String = "네",
+    onDismissRequest: () -> Unit = {},
+    onConfirmClicked: () -> Unit = {},
+    content: @Composable () -> Unit = {}
+) {
+    AnimatedVisibility(
+        visible = visible,
+        enter = slideInVertically(),
+        exit = slideOutVertically()
+    ) {
+        Dialog(
+            onDismissRequest = onDismissRequest,
+            properties = DialogProperties(
+                dismissOnClickOutside = true,
+                dismissOnBackPress = true
+            )
+        ) {
+            Column(
+                modifier = Modifier
+                    .width(305.dp)
+                    .clip(RoundedCornerShape(10.dp))
+                    .background(Color.White)
+                    .padding(20.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(text = title, style = DialogTitleStyle)
+                content()
+                Spacer(modifier = Modifier.height(24.dp))
+                Row {
+                    AppDialogButton(
+                        text = cancelButtonText,
+                        onClick = onDismissRequest
+                    )
+                    Spacer(modifier = Modifier.width(5.dp))
+                    AppDialogButton(
+                        enabled = enabled,
+                        text = confirmButtonText,
+                        backgroundColor = Color(0xFF858585),
+                        onClick = onConfirmClicked
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun AppDialogButton(
+    enabled: Boolean = true,
+    text: String = "",
+    backgroundColor: Color = Color.Black,
+    textColor: Color = Color.White,
+    onClick: () -> Unit = {}
+) {
+    Button(
+        modifier = Modifier.height(30.dp),
+        onClick = onClick,
+        enabled = enabled,
+        contentPadding = PaddingValues(horizontal = 0.dp),
+        shape = RoundedCornerShape(5.dp),
+        colors = ButtonDefaults.buttonColors(containerColor = backgroundColor)
+    ) {
+        Row {
+            Spacer(modifier = Modifier.width(30.dp))
+            Text(
+                text = text,
+                style = TextStyle(
+                    color = textColor,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 12.sp,
+                    letterSpacing = (-0.4).sp
+                )
+            )
+            Spacer(modifier = Modifier.width(30.dp))
+        }
+    }
+}
+
+@Composable
+fun WithdrawDialog(
+    showDialog: Boolean = true,
+    onConfirmClicked: () -> Unit = {},
+    onDismissRequest: () -> Unit = {}
+) {
+    val isChecked = remember { mutableStateOf(false) }
+    AppDialog(
+        title = "탈퇴 후 아래 기록과 계정 복구가 불가능해요.\n" +
+                "그래도 탈퇴하시겠어요?\n",
+        visible = showDialog,
+        enabled = isChecked.value,
+        onConfirmClicked = onConfirmClicked,
+        onDismissRequest = onDismissRequest,
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = "∙ 독서중인 책, 다 읽은 책\n" +
+                        "∙ 책의 첫인상, 생각 기록\n" +
+                        "∙ 내 책장",
+                style = TextStyle(
+                    color = Color(0xFF696969),
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Normal,
+                    letterSpacing = (-0.4).sp
+                ),
+                textAlign = TextAlign.Center
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Checkbox(
+                    checked = isChecked.value,
+                    onCheckedChange = { isChecked.value = !isChecked.value },
+                    modifier = Modifier.size(18.dp),
+//                    colors = CheckboxDefaults.colors()
+                )
+                Spacer(modifier = Modifier.width(10.dp))
+                Text(
+                    text = "네, 탈퇴할게요",
+                    style = TextStyle(
+                        color = Color.Black,
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        letterSpacing = (-0.4).sp
+                    )
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun AppDialogPreview() {
+    AppDialog("내용") {}
+}
+
+@Preview
+@Composable
+fun WithdrawDialogPreview() {
+    WithdrawDialog()
+}

--- a/data/src/main/java/project/side/ikdaman/data/data_source/AuthDataStore.kt
+++ b/data/src/main/java/project/side/ikdaman/data/data_source/AuthDataStore.kt
@@ -14,6 +14,7 @@ private val Context.AuthDatStore: DataStore<Preferences> by preferencesDataStore
 
 class AuthDataStore(private val context: Context) {
     companion object {
+        val PROVIDER_KEY = stringPreferencesKey("provider")
         val AUTHORIZATION_KEY = stringPreferencesKey("Authorization")
         val REFRESH_TOKEN_KEY = stringPreferencesKey("refresh-token")
         val NICKNAME_KEY = stringPreferencesKey("nickname")
@@ -23,12 +24,20 @@ class AuthDataStore(private val context: Context) {
         prefs[NICKNAME_KEY]
     }
 
+    suspend fun getProvider(): String? = context.AuthDatStore.data.first()[PROVIDER_KEY]
+
     suspend fun getAuthorization(): String? = context.AuthDatStore.data.first()[AUTHORIZATION_KEY]
 
     suspend fun getRefreshToken(): String? = context.AuthDatStore.data.first()[REFRESH_TOKEN_KEY]
 
-    suspend fun saveAuthInfo(authorization: String, refreshToken: String, nickname: String) {
+    suspend fun saveAuthInfo(
+        provider: String,
+        authorization: String,
+        refreshToken: String,
+        nickname: String
+    ) {
         context.AuthDatStore.edit { prefs ->
+            prefs[PROVIDER_KEY] = provider
             prefs[AUTHORIZATION_KEY] = authorization
             prefs[REFRESH_TOKEN_KEY] = refreshToken
             prefs[NICKNAME_KEY] = nickname

--- a/data/src/main/java/project/side/ikdaman/data/repository/AuthRepositoryImpl.kt
+++ b/data/src/main/java/project/side/ikdaman/data/repository/AuthRepositoryImpl.kt
@@ -26,7 +26,12 @@ class AuthRepositoryImpl @Inject constructor(
 
                 response.body()?.let {
                     if (!authorization.isNullOrBlank() && !refreshToken.isNullOrBlank()) {
-                        authDataStore.saveAuthInfo(authorization, refreshToken, it.nickname ?: "")
+                        authDataStore.saveAuthInfo(
+                            provider,
+                            authorization,
+                            refreshToken,
+                            it.nickname ?: ""
+                        )
                         ApiResult.Success(Unit)
                     } else ApiResult.Error("토큰이 비어있습니다.")
                 } ?: ApiResult.Error("응답이 비어있습니다.")

--- a/data/src/main/java/project/side/ikdaman/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/project/side/ikdaman/data/repository/UserRepositoryImpl.kt
@@ -15,6 +15,10 @@ class UserRepositoryImpl @Inject constructor(
 ) : UserRepository {
     override suspend fun getNickName(): Flow<String?> = authDataStore.nickname
 
+    override suspend fun getProvider(): String? = authDataStore.getProvider()
+
+    override suspend fun clearToken() = authDataStore.clear()
+
     override suspend fun checkNickname(nickname: String): ApiResult<Boolean> {
         return try {
             val response = userService.checkNickName(nickname)
@@ -53,6 +57,28 @@ class UserRepositoryImpl @Inject constructor(
                     authDataStore.saveNickname(it.nickname)
                     ApiResult.Success(Unit)
                 } ?: ApiResult.Error("응답이 비어있습니다.")
+            } else ApiResult.Error("서버 오류: ${response.code()}, ${response.message()}")
+        } catch (e: Exception) {
+            ApiResult.Error("서버 오류: ${e.message}")
+        }
+    }
+
+    override suspend fun logout(): ApiResult<Unit> {
+        return try {
+            val response = userService.logout()
+            if (response.isSuccessful) {
+                ApiResult.Success(Unit)
+            } else ApiResult.Error("서버 오류: ${response.code()}, ${response.message()}")
+        } catch (e: Exception) {
+            ApiResult.Error("서버 오류: ${e.message}")
+        }
+    }
+
+    override suspend fun withdraw(): ApiResult<Unit> {
+        return try {
+            val response = userService.withdraw()
+            if (response.isSuccessful) {
+                ApiResult.Success(Unit)
             } else ApiResult.Error("서버 오류: ${response.code()}, ${response.message()}")
         } catch (e: Exception) {
             ApiResult.Error("서버 오류: ${e.message}")

--- a/data/src/main/java/project/side/ikdaman/data/service/UserService.kt
+++ b/data/src/main/java/project/side/ikdaman/data/service/UserService.kt
@@ -5,6 +5,7 @@ import project.side.ikdaman.data.model.user.UserInfoResponse
 import project.side.ikdaman.domain.model.UserInfo
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.PUT
 import retrofit2.http.Query
@@ -22,4 +23,10 @@ interface UserService {
     suspend fun updateUserInfo(
         @Body userInfo: UserInfo
     ): Response<UserInfoResponse>
+
+    @DELETE("/auth/logout")
+    suspend fun logout(): Response<Unit>
+
+    @DELETE("/members/me")
+    suspend fun withdraw(): Response<Unit>
 }

--- a/domain/src/main/java/project/side/ikdaman/domain/repository/UserRepository.kt
+++ b/domain/src/main/java/project/side/ikdaman/domain/repository/UserRepository.kt
@@ -7,9 +7,17 @@ import project.side.ikdaman.domain.model.UserInfo
 interface UserRepository {
     suspend fun getNickName(): Flow<String?>
 
+    suspend fun getProvider(): String?
+
+    suspend fun clearToken()
+
     suspend fun checkNickname(nickname: String): ApiResult<Boolean>
 
     suspend fun getUserInfo(): ApiResult<UserInfo>
 
     suspend fun updateUserInfo(userInfo: UserInfo): ApiResult<Unit>
+
+    suspend fun logout(): ApiResult<Unit>
+
+    suspend fun withdraw(): ApiResult<Unit>
 }

--- a/domain/src/main/java/project/side/ikdaman/domain/usecase/AuthUseCase.kt
+++ b/domain/src/main/java/project/side/ikdaman/domain/usecase/AuthUseCase.kt
@@ -1,13 +1,26 @@
 package project.side.ikdaman.domain.usecase
 
-import project.side.ikdaman.domain.model.ApiResult
 import project.side.ikdaman.domain.repository.AuthRepository
+import project.side.ikdaman.domain.repository.UserRepository
 import javax.inject.Inject
 
-class AuthUseCase @Inject constructor(
-    private val authRepository: AuthRepository
-) {
-    suspend fun login(token: String, provider: String, providerId: String): ApiResult<Unit> {
-        return authRepository.login(token, provider, providerId)
-    }
+class LoginUseCase @Inject constructor(private val authRepository: AuthRepository) {
+    suspend operator fun invoke(token: String, provider: String, providerId: String) =
+        authRepository.login(token, provider, providerId)
+}
+
+class LogoutUseCase @Inject constructor(private val userRepository: UserRepository) {
+    suspend operator fun invoke() = userRepository.logout()
+}
+
+class WithdrawUseCase @Inject constructor(private val userRepository: UserRepository) {
+    suspend operator fun invoke() = userRepository.withdraw()
+}
+
+class GetProviderUseCase @Inject constructor(private val userRepository: UserRepository) {
+    suspend operator fun invoke() = userRepository.getProvider()
+}
+
+class ClearTokenUseCase @Inject constructor(private val userRepository: UserRepository) {
+    suspend operator fun invoke() = userRepository.clearToken()
 }

--- a/feature/src/main/java/project/side/ikdaman/feature/login/GoogleAuth.kt
+++ b/feature/src/main/java/project/side/ikdaman/feature/login/GoogleAuth.kt
@@ -2,6 +2,7 @@ package project.side.ikdaman.feature.login
 
 import android.content.Context
 import android.util.Base64
+import androidx.credentials.ClearCredentialStateRequest
 import androidx.credentials.CredentialManager
 import androidx.credentials.CustomCredential
 import androidx.credentials.GetCredentialRequest
@@ -44,6 +45,11 @@ object GoogleAuth {
                 }
             }
         }
+
+    suspend fun logout(context: Context) {
+        val credentialManager = CredentialManager.create(context)
+        credentialManager.clearCredentialState(ClearCredentialStateRequest())
+    }
 
     private fun handleSignIn(result: GetCredentialResponse): SocialLoginResult {
         val credential = result.credential

--- a/feature/src/main/java/project/side/ikdaman/feature/login/KakaoAuth.kt
+++ b/feature/src/main/java/project/side/ikdaman/feature/login/KakaoAuth.kt
@@ -98,4 +98,14 @@ object KakaoAuth {
                 UserApiClient.instance.loginWithKakaoAccount(context, callback = callback)
             }
         }
+
+    fun logout() {
+        UserApiClient.instance.logout {}
+    }
+
+    suspend fun unlink(): Boolean = suspendCancellableCoroutine { continuation ->
+        UserApiClient.instance.unlink { error ->
+            continuation.resume(error == null)
+        }
+    }
 }

--- a/feature/src/main/java/project/side/ikdaman/feature/login/LoginViewModel.kt
+++ b/feature/src/main/java/project/side/ikdaman/feature/login/LoginViewModel.kt
@@ -9,12 +9,12 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import project.side.ikdaman.domain.model.ApiResult
-import project.side.ikdaman.domain.usecase.AuthUseCase
+import project.side.ikdaman.domain.usecase.LoginUseCase
 import javax.inject.Inject
 
 @HiltViewModel
 class LoginViewModel @Inject constructor(
-    private val authUseCase: AuthUseCase
+    private val loginUseCase: LoginUseCase
 ) : ViewModel() {
     private val _loginState = MutableStateFlow<LoginState>(LoginState.Init)
     val loginState = _loginState.asStateFlow()
@@ -43,7 +43,7 @@ class LoginViewModel @Inject constructor(
                 val socialLoginResult = loginAction()
                 if (socialLoginResult.isSuccess) {
                     // 서버로 토큰 전송 및 저장
-                    val result = authUseCase.login(
+                    val result = loginUseCase(
                         socialLoginResult.socialAccessToken ?: "",
                         socialLoginResult.provider ?: "",
                         socialLoginResult.providerId ?: ""

--- a/feature/src/main/java/project/side/ikdaman/feature/login/NaverAuth.kt
+++ b/feature/src/main/java/project/side/ikdaman/feature/login/NaverAuth.kt
@@ -34,6 +34,26 @@ object NaverAuth {
             providerId = providerId
         )
     }
+
+    fun logout() {
+        NaverIdLoginSDK.logout()
+    }
+
+    suspend fun unlink() = suspendCancellableCoroutine { continuation ->
+        NidOAuthLogin().callDeleteTokenApi(object : OAuthLoginCallback {
+            override fun onSuccess() {
+                continuation.resume(true)
+            }
+
+            override fun onFailure(httpStatus: Int, message: String) {
+                continuation.resume(false)
+            }
+
+            override fun onError(errorCode: Int, message: String) {
+                continuation.resume(false)
+            }
+        })
+    }
 }
 
 private suspend fun getAccessToken(context: Context): Pair<String?, String?> =

--- a/feature/src/main/java/project/side/ikdaman/feature/mypage/AccountViewModel.kt
+++ b/feature/src/main/java/project/side/ikdaman/feature/mypage/AccountViewModel.kt
@@ -13,7 +13,9 @@ import project.side.ikdaman.domain.usecase.ClearTokenUseCase
 import project.side.ikdaman.domain.usecase.GetProviderUseCase
 import project.side.ikdaman.domain.usecase.LogoutUseCase
 import project.side.ikdaman.domain.usecase.WithdrawUseCase
+import project.side.ikdaman.feature.login.GoogleAuth
 import project.side.ikdaman.feature.login.KakaoAuth
+import project.side.ikdaman.feature.login.NaverAuth
 import project.side.ikdaman.feature.login.SocialLoginResult
 import javax.inject.Inject
 
@@ -44,11 +46,11 @@ class AccountViewModel @Inject constructor(
         _uiState.value = AccountState.Init
     }
 
-    fun logout() {
+    fun logout(context: Context) {
         when (provider.value) {
             "KAKAO" -> handleLogout { KakaoAuth.logout() }
-            "NAVER" -> {}
-            "GOOGLE" -> {}
+            "NAVER" -> handleLogout { NaverAuth.logout() }
+            "GOOGLE" -> handleLogout { GoogleAuth.logout(context) }
             else -> Unit
         }
     }
@@ -56,8 +58,8 @@ class AccountViewModel @Inject constructor(
     fun withdraw() {
         when (provider.value) {
             "KAKAO" -> handleWithdraw { KakaoAuth.unlink() }
-            "NAVER" -> {}
-            "GOOGLE" -> {}
+            "NAVER" -> handleWithdraw { NaverAuth.unlink() }
+            "GOOGLE" -> handleWithdraw { true }
             else -> Unit
         }
     }
@@ -69,9 +71,10 @@ class AccountViewModel @Inject constructor(
                 unlinkAction = { KakaoAuth.unlink() }
             )
 
-            "NAVER" -> Unit
-
-            "GOOGLE" -> Unit
+            "NAVER" -> reAuthAndUnlink(
+                loginAction = { NaverAuth.login(context) },
+                unlinkAction = { NaverAuth.unlink() }
+            )
 
             else -> Unit
         }

--- a/feature/src/main/java/project/side/ikdaman/feature/mypage/AccountViewModel.kt
+++ b/feature/src/main/java/project/side/ikdaman/feature/mypage/AccountViewModel.kt
@@ -1,0 +1,167 @@
+package project.side.ikdaman.feature.mypage
+
+import android.content.Context
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import project.side.ikdaman.domain.model.ApiResult
+import project.side.ikdaman.domain.usecase.ClearTokenUseCase
+import project.side.ikdaman.domain.usecase.GetProviderUseCase
+import project.side.ikdaman.domain.usecase.LogoutUseCase
+import project.side.ikdaman.domain.usecase.WithdrawUseCase
+import project.side.ikdaman.feature.login.KakaoAuth
+import project.side.ikdaman.feature.login.SocialLoginResult
+import javax.inject.Inject
+
+@HiltViewModel
+class AccountViewModel @Inject constructor(
+    private val logoutUseCase: LogoutUseCase,
+    private val withdrawUseCase: WithdrawUseCase,
+    private val clearTokenUseCase: ClearTokenUseCase,
+    private val getProviderUseCase: GetProviderUseCase,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow<AccountState>(AccountState.Init)
+    val uiState = _uiState.asStateFlow()
+
+    private val _provider = MutableStateFlow("")
+    val provider = _provider.asStateFlow()
+
+    init {
+        getProvider()
+    }
+
+    private fun getProvider() {
+        viewModelScope.launch {
+            _provider.value = getProviderUseCase() ?: ""
+        }
+    }
+
+    fun initAccountState() {
+        _uiState.value = AccountState.Init
+    }
+
+    fun logout() {
+        when (provider.value) {
+            "KAKAO" -> handleLogout { KakaoAuth.logout() }
+            "NAVER" -> {}
+            "GOOGLE" -> {}
+            else -> Unit
+        }
+    }
+
+    fun withdraw() {
+        when (provider.value) {
+            "KAKAO" -> handleWithdraw { KakaoAuth.unlink() }
+            "NAVER" -> {}
+            "GOOGLE" -> {}
+            else -> Unit
+        }
+    }
+
+    fun reAuth(context: Context) {
+        when (provider.value) {
+            "KAKAO" -> reAuthAndUnlink(
+                loginAction = { KakaoAuth.login(context) },
+                unlinkAction = { KakaoAuth.unlink() }
+            )
+
+            "NAVER" -> Unit
+
+            "GOOGLE" -> Unit
+
+            else -> Unit
+        }
+    }
+
+    private fun reAuthAndUnlink(
+        loginAction: suspend () -> SocialLoginResult,
+        unlinkAction: suspend () -> Boolean
+    ) {
+        _uiState.value = AccountState.Loading
+
+        viewModelScope.launch {
+            _uiState.value = try {
+                if (loginAction().isSuccess) {    // 소셜로그인만 다시 진행(소셜 토큰 만료 시)
+                    if (unlinkAction()) {
+                        AccountState.Success(SuccessType.WITHDRAW)
+                    } else {    // 서비스 회원 탈퇴 성공, 소셜로그인 연결 해제 실패
+                        AccountState.Error(ErrorType.UNLINK_FAILED, navigateToLogin = true)
+                    }
+                } else {
+                    AccountState.Error(ErrorType.RE_AUTH_FAILED)
+                }
+            } catch (e: Exception) {
+                AccountState.Error(ErrorType.UNKNOWN)
+            }
+        }
+    }
+
+    private fun handleLogout(logoutAction: suspend () -> Unit) {
+        _uiState.value = AccountState.Loading
+
+        viewModelScope.launch {
+            _uiState.value = try {
+                when (val result = logoutUseCase()) {
+                    is ApiResult.Success -> {
+                        logoutAction()  // 소셜 로그아웃
+                        clearTokenUseCase()
+                        AccountState.Success(SuccessType.LOGOUT)
+                    }
+
+                    is ApiResult.Error -> {
+                        Log.e("LOGOUT", "SERVER LOGOUT ERROR: ${result.message}")
+                        AccountState.Error(ErrorType.LOGOUT_FAILED)
+                    }
+
+                    is ApiResult.Loading -> AccountState.Loading
+                }
+            } catch (e: Exception) {
+                AccountState.Error(ErrorType.UNKNOWN)
+            }
+        }
+    }
+
+    private fun handleWithdraw(unlinkAction: suspend () -> Boolean) {
+        _uiState.value = AccountState.Loading
+
+        viewModelScope.launch {
+            _uiState.value = try {
+                when (val result = withdrawUseCase()) {
+                    is ApiResult.Success -> {
+                        if (unlinkAction()) {           //소셜 연결 해제 성공
+                            clearTokenUseCase()
+                            AccountState.Success(SuccessType.WITHDRAW)
+                        } else {
+                            AccountState.NeedToLogin(WarningType.NEED_RE_AUTH)    // 소셜 연결 해제 실패(소셜 토큰 만료 포함) -> 소셜만 재로그인
+                        }
+                    }
+
+                    is ApiResult.Error -> {
+                        Log.e("WITHDRAW", "SERVER WITHDRAW ERROR: ${result.message}")
+                        AccountState.Error(ErrorType.WITHDRAW_FAILED)
+                    }
+
+                    else -> AccountState.Loading
+                }
+            } catch (e: Exception) {
+                AccountState.Error(ErrorType.UNKNOWN)
+            }
+        }
+    }
+}
+
+enum class SuccessType { LOGOUT, WITHDRAW }
+enum class WarningType { NEED_RE_AUTH }
+enum class ErrorType { LOGOUT_FAILED, RE_AUTH_FAILED, UNLINK_FAILED, WITHDRAW_FAILED, UNKNOWN }
+
+sealed class AccountState {
+    data object Init : AccountState()
+    data object Loading : AccountState()
+    data class Success(val type: SuccessType) : AccountState()
+    data class NeedToLogin(val type: WarningType) : AccountState()
+    data class Error(val type: ErrorType, val navigateToLogin: Boolean = false) : AccountState()
+}

--- a/feature/src/main/java/project/side/ikdaman/feature/mypage/UserInfoScreen.kt
+++ b/feature/src/main/java/project/side/ikdaman/feature/mypage/UserInfoScreen.kt
@@ -54,11 +54,17 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import project.side.ikdaman.app.feature.R
+import project.side.ikdaman.core.navigation.LOGIN_ROUTE
 import project.side.ikdaman.domain.model.UserInfo
 
 @Composable
-fun UserInfoScreen(navController: NavController, viewModel: UserInfoViewModel = hiltViewModel()) {
+fun UserInfoScreen(
+    navController: NavController,
+    viewModel: UserInfoViewModel = hiltViewModel(),
+    accountViewModel: AccountViewModel = hiltViewModel()
+) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
+    val accountUiState = accountViewModel.uiState.collectAsStateWithLifecycle().value
     val context = LocalContext.current
 
     LaunchedEffect(Unit) {
@@ -67,17 +73,47 @@ fun UserInfoScreen(navController: NavController, viewModel: UserInfoViewModel = 
         }
     }
 
+    LaunchedEffect(accountUiState) {
+        val message = getMessage(accountUiState)
+        if (message != null) {
+            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+        }
+
+        when (accountUiState) {
+            is AccountState.Success -> navigateToLoginScreen(navController)
+            is AccountState.NeedToLogin -> accountViewModel.reAuth(context)
+            is AccountState.Error -> {
+                if (accountUiState.navigateToLogin) {
+                    navigateToLoginScreen(navController)
+                }
+                accountViewModel.initAccountState()
+            }
+
+            else -> Unit
+        }
+    }
+
     UserInfoScreenUI(
-        isLoading = uiState.isLoading,
+        isLoading = uiState.isLoading || accountUiState == AccountState.Loading,
         userInfo = uiState.userInfo,
         nicknameIsValid = uiState.nicknameIsValid,
         birthdateIsValid = uiState.birthdateIsValid,
         updateNicknameIsValid = viewModel::updateNicknameIsValid,
         updateBirthdateIsValid = viewModel::updateBirthdateIsValid,
         updateUserInfo = viewModel::updateUserInfo,
+        logout = accountViewModel::logout,
+        withdraw = accountViewModel::withdraw,
         checkNickname = viewModel::checkNickname
     ) {
         navController.popBackStack()
+    }
+}
+
+private fun navigateToLoginScreen(navController: NavController) {
+    navController.navigate(LOGIN_ROUTE) {
+        popUpTo(0) {
+            inclusive = true
+        }
     }
 }
 
@@ -91,6 +127,8 @@ fun UserInfoScreenUI(
     updateBirthdateIsValid: (String) -> Unit = {},
     checkNickname: (String) -> Unit = {},
     updateUserInfo: (String, String, String) -> Unit = { _, _, _ -> },
+    logout: () -> Unit = {},
+    withdraw: () -> Unit = {},
     navigateBack: () -> Unit = {}
 ) {
     val nickname = remember { mutableStateOf(TextFieldValue()) }
@@ -223,7 +261,7 @@ fun UserInfoScreenUI(
             Box(
                 modifier = Modifier
                     .height(26.dp)
-                    .clickable { },
+                    .clickable { logout() },
                 contentAlignment = Alignment.CenterStart
             ) {
                 Text("로그아웃", style = MyPageTextStyle.SubMenuText)
@@ -232,7 +270,7 @@ fun UserInfoScreenUI(
             Box(
                 modifier = Modifier
                     .height(26.dp)
-                    .clickable { },
+                    .clickable { withdraw() },
                 contentAlignment = Alignment.CenterStart
             ) {
                 Text("회원탈퇴", style = MyPageTextStyle.SubMenuText)
@@ -321,6 +359,29 @@ fun UserInfoTextField(
             ),
             textStyle = MyPageTextStyle.TextFieldText
         )
+    }
+}
+
+private fun getMessage(accountUiState: AccountState): String? {
+    return when (accountUiState) {
+        is AccountState.Success -> when (accountUiState.type) {
+            SuccessType.LOGOUT -> "로그아웃 되었습니다."
+            SuccessType.WITHDRAW -> "회원탈퇴 되었습니다."
+        }
+
+        is AccountState.NeedToLogin -> when (accountUiState.type) {
+            WarningType.NEED_RE_AUTH -> "인증 문제로 다시 로그인이 필요합니다."
+        }
+
+        is AccountState.Error -> when (accountUiState.type) {
+            ErrorType.LOGOUT_FAILED -> "로그아웃에 실패했습니다."
+            ErrorType.WITHDRAW_FAILED -> "회원 탈퇴에 실패했습니다."
+            ErrorType.UNLINK_FAILED -> "회원 탈퇴는 완료되었으나 소셜 연결 해제에 실패했습니다."
+            ErrorType.RE_AUTH_FAILED -> "소셜로그인에 실패했습니다."
+            ErrorType.UNKNOWN -> "오류가 발생했습니다. 잠시 후 다시 시도해 주세요."
+        }
+
+        else -> null
     }
 }
 

--- a/feature/src/main/java/project/side/ikdaman/feature/mypage/UserInfoScreen.kt
+++ b/feature/src/main/java/project/side/ikdaman/feature/mypage/UserInfoScreen.kt
@@ -1,5 +1,6 @@
 package project.side.ikdaman.feature.mypage
 
+import android.content.Context
 import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
@@ -94,6 +95,7 @@ fun UserInfoScreen(
     }
 
     UserInfoScreenUI(
+        context = context,
         isLoading = uiState.isLoading || accountUiState == AccountState.Loading,
         userInfo = uiState.userInfo,
         nicknameIsValid = uiState.nicknameIsValid,
@@ -119,6 +121,7 @@ private fun navigateToLoginScreen(navController: NavController) {
 
 @Composable
 fun UserInfoScreenUI(
+    context: Context = LocalContext.current,
     isLoading: Boolean = false,
     userInfo: UserInfo,
     nicknameIsValid: Boolean = true,
@@ -127,7 +130,7 @@ fun UserInfoScreenUI(
     updateBirthdateIsValid: (String) -> Unit = {},
     checkNickname: (String) -> Unit = {},
     updateUserInfo: (String, String, String) -> Unit = { _, _, _ -> },
-    logout: () -> Unit = {},
+    logout: (Context) -> Unit = {},
     withdraw: () -> Unit = {},
     navigateBack: () -> Unit = {}
 ) {
@@ -261,7 +264,7 @@ fun UserInfoScreenUI(
             Box(
                 modifier = Modifier
                     .height(26.dp)
-                    .clickable { logout() },
+                    .clickable { logout(context) },
                 contentAlignment = Alignment.CenterStart
             ) {
                 Text("로그아웃", style = MyPageTextStyle.SubMenuText)

--- a/feature/src/main/java/project/side/ikdaman/feature/mypage/UserInfoScreen.kt
+++ b/feature/src/main/java/project/side/ikdaman/feature/mypage/UserInfoScreen.kt
@@ -1,6 +1,5 @@
 package project.side.ikdaman.feature.mypage
 
-import android.content.Context
 import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
@@ -56,6 +55,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import project.side.ikdaman.app.feature.R
 import project.side.ikdaman.core.navigation.LOGIN_ROUTE
+import project.side.ikdaman.core.view.AppDialog
+import project.side.ikdaman.core.view.WithdrawDialog
 import project.side.ikdaman.domain.model.UserInfo
 
 @Composable
@@ -67,6 +68,9 @@ fun UserInfoScreen(
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
     val accountUiState = accountViewModel.uiState.collectAsStateWithLifecycle().value
     val context = LocalContext.current
+    val showLogoutDialog = remember { mutableStateOf(false) }
+    val showWithdrawDialog = remember { mutableStateOf(false) }
+    val showRealWithdrawDialog = remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
         viewModel.uiEvent.collect { message ->
@@ -94,8 +98,36 @@ fun UserInfoScreen(
         }
     }
 
+    if (showLogoutDialog.value) {
+        AppDialog(
+            title = "읽다만에서\n로그아웃하시겠어요?",
+            visible = showLogoutDialog.value,
+            onDismissRequest = { showLogoutDialog.value = false },
+            onConfirmClicked = { accountViewModel.logout(context) },
+        )
+    }
+
+    if (showWithdrawDialog.value) {
+        AppDialog(
+            title = "읽다만에서\n탈퇴하시겠어요?",
+            visible = showWithdrawDialog.value,
+            onDismissRequest = { showWithdrawDialog.value = false },
+            onConfirmClicked = {
+                showRealWithdrawDialog.value = true
+                showWithdrawDialog.value = false
+            },
+        )
+    }
+
+    if (showRealWithdrawDialog.value) {
+        WithdrawDialog(
+            showDialog = showRealWithdrawDialog.value,
+            onConfirmClicked = accountViewModel::withdraw,
+            onDismissRequest = { showRealWithdrawDialog.value = false }
+        )
+    }
+
     UserInfoScreenUI(
-        context = context,
         isLoading = uiState.isLoading || accountUiState == AccountState.Loading,
         userInfo = uiState.userInfo,
         nicknameIsValid = uiState.nicknameIsValid,
@@ -103,8 +135,8 @@ fun UserInfoScreen(
         updateNicknameIsValid = viewModel::updateNicknameIsValid,
         updateBirthdateIsValid = viewModel::updateBirthdateIsValid,
         updateUserInfo = viewModel::updateUserInfo,
-        logout = accountViewModel::logout,
-        withdraw = accountViewModel::withdraw,
+        onLogoutClicked = { showLogoutDialog.value = true },
+        onWithdrawClicked = { showWithdrawDialog.value = true },
         checkNickname = viewModel::checkNickname
     ) {
         navController.popBackStack()
@@ -121,7 +153,6 @@ private fun navigateToLoginScreen(navController: NavController) {
 
 @Composable
 fun UserInfoScreenUI(
-    context: Context = LocalContext.current,
     isLoading: Boolean = false,
     userInfo: UserInfo,
     nicknameIsValid: Boolean = true,
@@ -130,8 +161,8 @@ fun UserInfoScreenUI(
     updateBirthdateIsValid: (String) -> Unit = {},
     checkNickname: (String) -> Unit = {},
     updateUserInfo: (String, String, String) -> Unit = { _, _, _ -> },
-    logout: (Context) -> Unit = {},
-    withdraw: () -> Unit = {},
+    onLogoutClicked: () -> Unit = {},
+    onWithdrawClicked: () -> Unit = {},
     navigateBack: () -> Unit = {}
 ) {
     val nickname = remember { mutableStateOf(TextFieldValue()) }
@@ -264,7 +295,7 @@ fun UserInfoScreenUI(
             Box(
                 modifier = Modifier
                     .height(26.dp)
-                    .clickable { logout(context) },
+                    .clickable { onLogoutClicked() },
                 contentAlignment = Alignment.CenterStart
             ) {
                 Text("로그아웃", style = MyPageTextStyle.SubMenuText)
@@ -273,7 +304,7 @@ fun UserInfoScreenUI(
             Box(
                 modifier = Modifier
                     .height(26.dp)
-                    .clickable { withdraw() },
+                    .clickable { onWithdrawClicked() },
                 contentAlignment = Alignment.CenterStart
             ) {
                 Text("회원탈퇴", style = MyPageTextStyle.SubMenuText)

--- a/feature/src/main/java/project/side/ikdaman/feature/mypage/UserInfoViewModel.kt
+++ b/feature/src/main/java/project/side/ikdaman/feature/mypage/UserInfoViewModel.kt
@@ -98,6 +98,7 @@ class UserInfoViewModel @Inject constructor(
                 }
 
                 is ApiResult.Error -> {
+                    _uiState.value = _uiState.value.copy(isLoading = false)
                     _uiEvent.emit("오류가 발생했습니다. 잠시 후 다시 시도해 주세요.")
                 }
 


### PR DESCRIPTION
- 로그아웃, 회원 탈퇴 팝업 추가, API 연결

**[참고]**
- 로그아웃: 소셜 로그아웃, 서버 로그아웃
   - 소셜 로그아웃은 그냥 토큰을 지우는 용도라 토큰이 유효한지 확인하지 않아도 됨 
- 회원탈퇴: 소셜 연결해제, 서버 회원탈퇴
   - 소셜 연결해제는 토큰이 유효해야지 연결 해제가 가능
   - 그래서 연결 해제가 실패하면 저희 서비스 로그인이 아니라 소셜만 재로그인해서 연결 해제하도록 구현했습니다~
   - 구글은 연결 해제를 따로 제공하지 않아서 그냥 저희 서비스 탈퇴만 구현했습니다
      - 기존에 있던 API가 안드로이드에서 deprecated 돼서 아마 연결 해제작업은 서버에서 진행되어야 할 것 같습니다
      - 민정님한테 전달은 해놓겠습니당

자동로그인은 pr 따로 올릴게요🙇🏻‍♂️
 